### PR TITLE
Handle IgnoreUnmappedParams in AWS param store

### DIFF
--- a/aws/aws_param_store.go
+++ b/aws/aws_param_store.go
@@ -60,7 +60,13 @@ func LoadConfigFromParameterStore(awsConfig aws.Config, options LoadConfigOption
 
 	errors := paramTree.Write(reflectedConfig)
 
-	return errors.Join()
+	joinedError := errors.Join()
+
+	if joinedError.Warning() && options.IgnoreUnmappedParams {
+		return nil
+	}
+
+	return joinedError
 }
 
 type param struct {


### PR DESCRIPTION
#7 contained a bug - it does not take the `IgnoreUnmappedParams` option into account. This PR fixes that.