### PR TITLE
Support full range of numeric types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 linters:
   enable-all: true
   disable:
+    # anarchy in the comments section
+    - godox
+    - godot
+
     # not very convenient
     - exhaustruct
 

--- a/tree/errors_test.go
+++ b/tree/errors_test.go
@@ -12,10 +12,12 @@ func TestAllKindsOfErrors(t *testing.T) {
 
 	tree := &Node{
 		Children: map[string]*Node{
-			"Str":   {Value: "foo"},
-			"int":   {Value: "not an int"},
-			"float": {Value: "1.23"},
-			"bool":  {Value: "yes"},
+			"Str":     {Value: "foo"},
+			"int":     {Value: "not an int"},
+			"int32":   {Value: "1000000000000"},
+			"uint":    {Value: "-1"},
+			"complex": {Value: "unsupported type"},
+			"bool":    {Value: "yes"},
 			"intmap": {
 				Children: map[string]*Node{
 					"foo": {Value: "bad int"},
@@ -47,7 +49,7 @@ func TestAllKindsOfErrors(t *testing.T) {
 
 	expectedErrors := []writeError{
 		{
-			msg:         "cannot read int param value",
+			msg:         `cannot read int param value: strconv.ParseInt: parsing "not an int": invalid syntax`,
 			path:        "int",
 			isPathError: false,
 		},
@@ -57,17 +59,27 @@ func TestAllKindsOfErrors(t *testing.T) {
 			isPathError: false,
 		},
 		{
-			msg:         "cannot write param: config key is of unsupported type float64",
-			path:        "float",
+			msg:         `cannot read int32 param value: strconv.ParseInt: parsing "1000000000000": value out of range`,
+			path:        "int32",
 			isPathError: false,
 		},
 		{
-			msg:         "cannot read int param value",
+			msg:         `cannot read uint16 param value: strconv.ParseUint: parsing "-1": invalid syntax`,
+			path:        "uint",
+			isPathError: false,
+		},
+		{
+			msg:         "cannot write param: config key is of unsupported type complex64",
+			path:        "complex",
+			isPathError: false,
+		},
+		{
+			msg:         `cannot read int param value: strconv.ParseInt: parsing "bad int": invalid syntax`,
 			path:        "intmap/foo",
 			isPathError: false,
 		},
 		{
-			msg:         "cannot read int param value",
+			msg:         `cannot read int param value: strconv.ParseInt: parsing "bad int": invalid syntax`,
 			path:        "intslice/0",
 			isPathError: false,
 		},

--- a/tree/leaf.go
+++ b/tree/leaf.go
@@ -14,25 +14,56 @@ func (paramTree Node) writeLeafValue(destination reflect.Value) WriteErrors {
 	switch destination.Kind() { //nolint:exhaustive // we don't cover all types
 	case reflect.String:
 		destination.SetString(paramTree.Value)
-	case reflect.Int:
-		intval, err := strconv.Atoi(paramTree.Value)
-		if err != nil {
-			return newWriteErrors("cannot read int param value")
-		}
-		destination.SetInt(int64(intval))
+		return WriteErrors{}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return writeInt(paramTree.Value, destination)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return writeUint(paramTree.Value, destination)
+	case reflect.Float64, reflect.Float32:
+		return writeFloat(paramTree.Value, destination)
 	case reflect.Bool:
-		switch paramTree.Value {
-		case "true":
-			destination.SetBool(true)
-		case "false":
-			destination.SetBool(false)
-		default:
-			return newWriteErrors("cannot read bool param value (must be true or false)")
-		}
+		return writeBool(paramTree.Value, destination)
 	default:
 		err := fmt.Sprintf("cannot write param: config key is of unsupported type %s", destination.Kind())
 		return newWriteErrors(err)
 	}
+}
 
+func writeInt(source string, destination reflect.Value) WriteErrors {
+	intval, err := strconv.ParseInt(source, 10, destination.Type().Bits())
+	if err != nil {
+		return newWriteErrors(fmt.Sprintf("cannot read %v param value: %v", destination.Kind(), err))
+	}
+	destination.SetInt(intval)
+	return WriteErrors{}
+}
+
+func writeUint(source string, destination reflect.Value) WriteErrors {
+	uintval, err := strconv.ParseUint(source, 10, destination.Type().Bits())
+	if err != nil {
+		return newWriteErrors(fmt.Sprintf("cannot read %v param value: %v", destination.Kind(), err))
+	}
+	destination.SetUint(uintval)
+	return WriteErrors{}
+}
+
+func writeFloat(source string, destination reflect.Value) WriteErrors {
+	floatval, err := strconv.ParseFloat(source, destination.Type().Bits())
+	if err != nil {
+		return newWriteErrors(fmt.Sprintf("cannot read %v param value: %v", destination.Kind(), err))
+	}
+	destination.SetFloat(floatval)
+	return WriteErrors{}
+}
+
+func writeBool(source string, destination reflect.Value) WriteErrors {
+	switch source {
+	case "true":
+		destination.SetBool(true)
+	case "false":
+		destination.SetBool(false)
+	default:
+		return newWriteErrors("cannot read bool param value (must be true or false)")
+	}
 	return WriteErrors{}
 }

--- a/tree/write_test.go
+++ b/tree/write_test.go
@@ -11,6 +11,9 @@ import (
 type testStructType struct {
 	Str            string                     `json:"str"`
 	Int            int                        `global:"int"`
+	Int32          int32                      `json:"int32"`
+	Uint           uint16                     `json:"uint"`
+	Float          float64                    `global:"float"`
 	Bool           bool                       `json:"bool"`
 	StrMap         map[string]string          `json:"strmap"`
 	StrSlice       []string                   `json:"strslice"`
@@ -24,20 +27,24 @@ type testStructType struct {
 	SliceOfMap     []map[string]string        `json:"sliceofmap"`
 	MapOfSlice     map[string][]string        `json:"mapofslice"`
 	// Fields just for testing errors
-	Float  float64        `global:"float"`
-	BadMap map[int]string `json:"badmap"`
+	Complex64 complex64      `global:"complex"`
+	BadMap    map[int]string `json:"badmap"`
 }
 
-func TestWrite(t *testing.T) {
+// TODO: maybe split the test into atomic parts so it's not so hard to review
+func TestWrite(t *testing.T) { //nolint:maintidx
 	t.Parallel()
 
 	var testStruct testStructType
 
 	tree := &Node{
 		Children: map[string]*Node{
-			"Str":  {Value: "foo"},
-			"int":  {Value: "123"},
-			"bool": {Value: "true"},
+			"Str":   {Value: "foo"},
+			"int":   {Value: "123"},
+			"int32": {Value: "65536"},
+			"uint":  {Value: "10"},
+			"float": {Value: "1.23"},
+			"bool":  {Value: "true"},
 			"intmap": {
 				Children: map[string]*Node{
 					"foo": {Value: "123"},
@@ -129,9 +136,12 @@ func TestWrite(t *testing.T) {
 	require.False(t, errors.Present())
 
 	expectedStruct := testStructType{
-		Str:  "foo",
-		Int:  123,
-		Bool: true,
+		Str:   "foo",
+		Int:   123,
+		Int32: 65536,
+		Uint:  10,
+		Float: 1.23,
+		Bool:  true,
 		IntMap: map[string]int{
 			"foo": 123,
 			"bar": 456,
@@ -265,9 +275,12 @@ func TestWrite(t *testing.T) {
 	require.False(t, errors.Present())
 
 	expectedMergedStruct := testStructType{
-		Str:  "bar",
-		Int:  456,
-		Bool: false,
+		Str:   "bar",
+		Int:   456,
+		Int32: 65536,
+		Uint:  10,
+		Float: 1.23,
+		Bool:  false,
 		IntMap: map[string]int{
 			"foo": 123,
 			"bar": 4560,


### PR DESCRIPTION
- All ints
- All uints
- All floats
- Refactor a bit
- use `strconv.Parse*` methods to explicitly specify bitness
- expose specific parsing error to the consumer