### PR TITLE
Improve error message when attempting to write a leaf value into a composite type

### DIFF
--- a/tree/errors_test.go
+++ b/tree/errors_test.go
@@ -35,6 +35,7 @@ func TestAllKindsOfErrors(t *testing.T) {
 					"bad_field": {Value: "foo"},
 				},
 			},
+			"another_nested": {Value: "string_value_for_struct"},
 			"badmap": {
 				Children: map[string]*Node{
 					"0": {Value: "foo"},
@@ -97,6 +98,11 @@ func TestAllKindsOfErrors(t *testing.T) {
 			msg:         "unknown field",
 			path:        "nested/bad_field",
 			isPathError: true,
+		},
+		{
+			msg:         "cannot write param: destination should be a primitive type, not a struct",
+			path:        "another_nested",
+			isPathError: false,
 		},
 		{
 			msg:         "can only write to maps with string keys",

--- a/tree/leaf.go
+++ b/tree/leaf.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-func (paramTree Node) writeLeafValue(destination reflect.Value) WriteErrors {
+func (paramTree Node) writeLeafValue(destination reflect.Value) WriteErrors { //nolint:cyclop
 	if !destination.CanSet() {
 		return newWriteErrors("value is not writable")
 	}
@@ -23,6 +23,12 @@ func (paramTree Node) writeLeafValue(destination reflect.Value) WriteErrors {
 		return writeFloat(paramTree.Value, destination)
 	case reflect.Bool:
 		return writeBool(paramTree.Value, destination)
+	case reflect.Struct:
+		return newWriteErrors("cannot write param: destination should be a primitive type, not a struct")
+	case reflect.Map:
+		return newWriteErrors("cannot write param: destination should be a primitive type, not a map")
+	case reflect.Slice:
+		return newWriteErrors("cannot write param: destination should be a primitive type, not a slice")
 	default:
 		err := fmt.Sprintf("cannot write param: config key is of unsupported type %s", destination.Kind())
 		return newWriteErrors(err)

--- a/tree/write_test.go
+++ b/tree/write_test.go
@@ -20,6 +20,7 @@ type testStructType struct {
 	IntMap         map[string]int             `json:"intmap"`
 	IntSlice       []int                      `json:"intslice"`
 	Nested         *testStructType            `json:"nested"`
+	AnotherNested  nestedType                 `json:"another_nested"`
 	NestedMap      map[string]testStructType  `json:"nmap"`
 	NestedMapPtr   map[string]*testStructType `json:"nmapptr"`
 	NestedSlice    []testStructType           `json:"nslice"`
@@ -29,6 +30,10 @@ type testStructType struct {
 	// Fields just for testing errors
 	Complex64 complex64      `global:"complex"`
 	BadMap    map[int]string `json:"badmap"`
+}
+
+type nestedType struct {
+	NestedField string `json:"nested_field"`
 }
 
 // TODO: maybe split the test into atomic parts so it's not so hard to review
@@ -73,6 +78,11 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 			"nested": {
 				Children: map[string]*Node{
 					"str": {Value: "nested_foo"},
+				},
+			},
+			"another_nested": {
+				Children: map[string]*Node{
+					"nested_field": {Value: "nested_without_pointer"},
 				},
 			},
 			"nmap": {
@@ -150,9 +160,10 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 			"foo": "bar",
 			"baz": "qux",
 		},
-		IntSlice: []int{12, 34},
-		StrSlice: []string{"foo", "", "bar"},
-		Nested:   &testStructType{Str: "nested_foo"},
+		IntSlice:      []int{12, 34},
+		StrSlice:      []string{"foo", "", "bar"},
+		Nested:        &testStructType{Str: "nested_foo"},
+		AnotherNested: nestedType{NestedField: "nested_without_pointer"},
 		NestedMap: map[string]testStructType{
 			"foo": {
 				Str: "nested_foo_in_map",
@@ -291,9 +302,10 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 			"baz": "bam",
 			"zip": "zap",
 		},
-		IntSlice: []int{56, 34, 90},
-		StrSlice: []string{"foo", "baz", "bar"},
-		Nested:   &testStructType{Str: "nested_foo", Int: 1234},
+		IntSlice:      []int{56, 34, 90},
+		StrSlice:      []string{"foo", "baz", "bar"},
+		Nested:        &testStructType{Str: "nested_foo", Int: 1234},
+		AnotherNested: nestedType{NestedField: "nested_without_pointer"},
 		NestedMap: map[string]testStructType{
 			"foo": {
 				Str: "nested_foo_in_map",


### PR DESCRIPTION
Before the error was misleading:

```
cannot write param: config key is of unsupported type struct
```

We do support `structs`, as long as you don't try to write a leaf value into them.