### PR TITLE
Return warning if there were no parameters in Parameter Store

### DIFF
--- a/aws/aws_param_store.go
+++ b/aws/aws_param_store.go
@@ -58,6 +58,10 @@ func LoadConfigFromParameterStore( //nolint:nonamedreturns // false positive, us
 		}
 	}
 
+	if len(params) == 0 {
+		return global.NewWarning("global: no parameters in Parameter Store with prefix \"%s\"", options.ParamPrefix)
+	}
+
 	paramTree := buildParamTree(params)
 
 	errors := paramTree.Write(reflectedConfig)


### PR DESCRIPTION
Prior to this change ths actually resulted in an error:

```
global: : cannot write param: config key is of unsupported type struct
```

this was because the generated parameter tree was empty; this is only possible if parameters are empty, so I decided not to add special handling for empty parameter tree nodes (it can have other uses.)