### PR TITLE
Support encoding.TextUnmarshaler

### DIFF
--- a/tree/leaf.go
+++ b/tree/leaf.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -9,6 +10,11 @@ import (
 func (paramTree Node) writeLeafValue(destination reflect.Value) WriteErrors { //nolint:cyclop
 	if !destination.CanSet() {
 		return newWriteErrors("value is not writable")
+	}
+
+	// If destination implements TextUnmarshaler, it takes priority
+	if handled, unmarshalerErrors := tryWriteUnmarshaler(paramTree.Value, destination); handled {
+		return unmarshalerErrors
 	}
 
 	switch destination.Kind() { //nolint:exhaustive // we don't cover all types
@@ -70,6 +76,32 @@ func writeBool(source string, destination reflect.Value) WriteErrors {
 		destination.SetBool(false)
 	default:
 		return newWriteErrors("cannot read bool param value (must be true or false)")
+	}
+	return WriteErrors{}
+}
+
+func tryWriteUnmarshaler(source string, destination reflect.Value) (bool, WriteErrors) {
+	if destination.CanInterface() {
+		if unmarshaler, ok := destination.Interface().(encoding.TextUnmarshaler); ok {
+			return true, writeUnmarshaler(source, unmarshaler)
+		}
+	}
+
+	// In some cases unmarshaling requires a pointer receiver. So if the value itself does not implement the interface,
+	// check a pointer to it as well.
+	if destination.CanAddr() {
+		if unmarshaler, ok := destination.Addr().Interface().(encoding.TextUnmarshaler); ok {
+			return true, writeUnmarshaler(source, unmarshaler)
+		}
+	}
+
+	return false, WriteErrors{}
+}
+
+func writeUnmarshaler(source string, unmarshaler encoding.TextUnmarshaler) WriteErrors {
+	err := unmarshaler.UnmarshalText([]byte(source))
+	if err != nil {
+		return newWriteErrors(fmt.Sprintf("cannot write param: UnmarshalText returned error: %v", err))
 	}
 	return WriteErrors{}
 }

--- a/tree/write_test.go
+++ b/tree/write_test.go
@@ -27,6 +27,7 @@ type testStructType struct {
 	NestedSlicePtr []*testStructType          `json:"nsliceptr"`
 	SliceOfMap     []map[string]string        `json:"sliceofmap"`
 	MapOfSlice     map[string][]string        `json:"mapofslice"`
+	Unmarshalable  unmarshalableType          `json:"unmarshalable"`
 	// Fields just for testing errors
 	Complex64 complex64      `global:"complex"`
 	BadMap    map[int]string `json:"badmap"`
@@ -34,6 +35,15 @@ type testStructType struct {
 
 type nestedType struct {
 	NestedField string `json:"nested_field"`
+}
+
+type unmarshalableType struct {
+	value string
+}
+
+func (u *unmarshalableType) UnmarshalText(text []byte) error {
+	u.value = string(text)
+	return nil
 }
 
 // TODO: maybe split the test into atomic parts so it's not so hard to review
@@ -139,11 +149,12 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 					},
 				},
 			},
+			"unmarshalable": {Value: "unmarshaled_value"},
 		},
 	}
 
 	errors := tree.Write(reflect.ValueOf(&testStruct))
-	require.False(t, errors.Present())
+	require.False(t, errors.Present(), "had errors: %v", errors.Join())
 
 	expectedStruct := testStructType{
 		Str:   "foo",
@@ -178,6 +189,7 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 		NestedSlicePtr: []*testStructType{{Str: "nested_foo_in_slice_ptr"}},
 		SliceOfMap:     []map[string]string{{"foo": "map_in_slice"}},
 		MapOfSlice:     map[string][]string{"foo": {"slice_in_map"}},
+		Unmarshalable:  unmarshalableType{value: "unmarshaled_value"},
 	}
 
 	assert.Equal(t, expectedStruct, testStruct, "assignment works correctly")
@@ -328,6 +340,7 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 		NestedSlicePtr: []*testStructType{{Str: "updated_foo_in_slice_ptr"}},
 		SliceOfMap:     []map[string]string{{"foo": "updated_map_in_slice"}},
 		MapOfSlice:     map[string][]string{"foo": {"updated_slice_in_map"}},
+		Unmarshalable:  unmarshalableType{value: "unmarshaled_value"},
 	}
 
 	assert.Equal(t, expectedMergedStruct, testStruct, "merging changes works correctly")


### PR DESCRIPTION
https://pkg.go.dev/encoding@go1.23.0#TextUnmarshaler

>TextUnmarshaler is the interface implemented by an object that can unmarshal a textual representation of itself.

As we are essentially dealing exactly with text unmarshalling throughout this library, it makes sense to support `TextUnmarshaler` and let the consumer implement their own way of interpeting parameter values.
