### PR TITLE
Support decoding Base64 encoded bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,17 @@ err := globalAWS.LoadConfigFromParameterStore(
 // config.Database.PoolSize loaded from /param_prefix/database/pool_size
 ```
 
-Supported value types: `string`, `int`, `bool` ("true"/"false").
+- Supported value types: `string`, `int`, `bool` ("true"/"false").
 
-Complex type should be either a `struct`, a `map` or a `slice`. You can arbitrarily nest them.
+- A `[]byte` can be loaded from Base64 encoded string.
 
-For structs, use `global` or `json` tag to set field name.
+- Complex type should be either a `struct`, a `map` or a `slice`. You can arbitrarily nest them.
 
-For maps, the key name is the map key (maps must use strings as keys.)
+- For structs, use `global` or `json` tag to set field name.
 
-For slices, all subscripts in Parameter Store must be integers.
+- For maps, the key name is the map key (maps must use strings as keys.)
+
+- For slices, all subscripts in Parameter Store must be integers.
 
 ### Shorthand for running on AWS ECS or Lambda
 

--- a/tree/errors_test.go
+++ b/tree/errors_test.go
@@ -41,6 +41,7 @@ func TestAllKindsOfErrors(t *testing.T) {
 					"0": {Value: "foo"},
 				},
 			},
+			"bytes": {Value: "??notbase64"},
 		},
 	}
 
@@ -107,6 +108,11 @@ func TestAllKindsOfErrors(t *testing.T) {
 		{
 			msg:         "can only write to maps with string keys",
 			path:        "badmap",
+			isPathError: false,
+		},
+		{
+			msg:         "could not decode base64: illegal base64 data at input byte 0",
+			path:        "bytes",
 			isPathError: false,
 		},
 	}

--- a/tree/leaf.go
+++ b/tree/leaf.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"encoding"
+	"encoding/base64"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -34,6 +35,9 @@ func (paramTree Node) writeLeafValue(destination reflect.Value) WriteErrors { //
 	case reflect.Map:
 		return newWriteErrors("cannot write param: destination should be a primitive type, not a map")
 	case reflect.Slice:
+		if destination.Type().Elem().Kind() == reflect.Uint8 {
+			return writeBase64(paramTree.Value, destination)
+		}
 		return newWriteErrors("cannot write param: destination should be a primitive type, not a slice")
 	default:
 		err := fmt.Sprintf("cannot write param: config key is of unsupported type %s", destination.Kind())
@@ -77,6 +81,15 @@ func writeBool(source string, destination reflect.Value) WriteErrors {
 	default:
 		return newWriteErrors("cannot read bool param value (must be true or false)")
 	}
+	return WriteErrors{}
+}
+
+func writeBase64(source string, destination reflect.Value) WriteErrors {
+	bytes, err := base64.StdEncoding.DecodeString(source)
+	if err != nil {
+		return newWriteErrors(fmt.Sprintf("could not decode base64: %v", err))
+	}
+	destination.SetBytes(bytes)
 	return WriteErrors{}
 }
 

--- a/tree/write_test.go
+++ b/tree/write_test.go
@@ -28,6 +28,7 @@ type testStructType struct {
 	SliceOfMap     []map[string]string        `json:"sliceofmap"`
 	MapOfSlice     map[string][]string        `json:"mapofslice"`
 	Unmarshalable  unmarshalableType          `json:"unmarshalable"`
+	Bytes          []byte                     `json:"bytes"`
 	// Fields just for testing errors
 	Complex64 complex64      `global:"complex"`
 	BadMap    map[int]string `json:"badmap"`
@@ -150,6 +151,7 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 				},
 			},
 			"unmarshalable": {Value: "unmarshaled_value"},
+			"bytes":         {Value: "ZGF0YQ=="},
 		},
 	}
 
@@ -190,6 +192,7 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 		SliceOfMap:     []map[string]string{{"foo": "map_in_slice"}},
 		MapOfSlice:     map[string][]string{"foo": {"slice_in_map"}},
 		Unmarshalable:  unmarshalableType{value: "unmarshaled_value"},
+		Bytes:          []byte{'d', 'a', 't', 'a'},
 	}
 
 	assert.Equal(t, expectedStruct, testStruct, "assignment works correctly")
@@ -341,6 +344,7 @@ func TestWrite(t *testing.T) { //nolint:maintidx
 		SliceOfMap:     []map[string]string{{"foo": "updated_map_in_slice"}},
 		MapOfSlice:     map[string][]string{"foo": {"updated_slice_in_map"}},
 		Unmarshalable:  unmarshalableType{value: "unmarshaled_value"},
+		Bytes:          []byte{'d', 'a', 't', 'a'},
 	}
 
 	assert.Equal(t, expectedMergedStruct, testStruct, "merging changes works correctly")


### PR DESCRIPTION
Motivation: allow loading binary data from the store. 

This reproduces the behavior of the `encoding/json` decoder.